### PR TITLE
Rblott/bash exit on fail

### DIFF
--- a/terragrunt-multi-envs/templates/job-terragruntapply-template.yaml
+++ b/terragrunt-multi-envs/templates/job-terragruntapply-template.yaml
@@ -30,6 +30,8 @@ jobs:
             - download: none
             #- checkout: self # removed due multiple issues. Using scripted checkout instead.
             - bash: |
+                set -euo pipefail
+
                 if [ ! -d "$(Agent.ToolsDirectory)/.tfenv" ]; then
                 git clone --depth=1 https://github.com/ssc-spc-cloud-nuage/tfenv.git $(Agent.ToolsDirectory)/.tfenv
                 echo 'export PATH=$(Agent.ToolsDirectory)/.tfenv/bin:$PATH' >> ~/.profile

--- a/terragrunt-multi-envs/templates/job-terragruntplan-template.yaml
+++ b/terragrunt-multi-envs/templates/job-terragruntplan-template.yaml
@@ -39,6 +39,8 @@ jobs:
           scriptLocation: inlineScript
           addSpnToEnvironment: true
           inlineScript: |
+            set -euo pipefail
+
             export ARM_CLIENT_ID=$servicePrincipalId
             export ARM_OIDC_TOKEN=$idToken
             export ARM_TENANT_ID=$tenantId

--- a/terragrunt-multi-envs/templates/stage-elszenvs-template.yaml
+++ b/terragrunt-multi-envs/templates/stage-elszenvs-template.yaml
@@ -21,6 +21,8 @@ stages:
         steps:
           - checkout: none
           - bash: |
+              set -euo pipefail
+
               if ! command -v jq &> /dev/null; then
                 sudo apt-get update
                 sudo apt-get install -y jq


### PR DESCRIPTION
Today we had the InitJob/InstallTools step fail to install the desired tg version with tgenv, but the yaml step succeeded and the rest of the pipeline kept running. Once it got to TerragruntPlan_ENV_LAYER/TerragruntInit the install of tg failed again and the pipeline died there.

Arguably the InitJob yaml step should have failed and not gone on to any of the gitdiff/tg plan steps. I can't really test this change but `set -euo pipefail` is usually a safe way to start bash scripts.



InitJob/InstallTools
```
...

Installation of terraform v1.11.3 successful. To make this your default version, run 'tfenv use 1.11.3'
Switching default version to v1.11.3
Default version (when not overridden by .terraform-version or TFENV_TERRAFORM_VERSION) is now: 1.11.3
Cloning into '/azp/_work/_tool/.tgenv'...
No versions matching '0.77.7' found in remote
No installed versions of terragrunt matched '0.77.7:^0.77.7$'. Trying to install a matching version since TGENV_AUTO_INSTALL=true
No versions matching '0.77.7' found in remote
Installing a matching version failed

Finishing: InstallTools
```

TerragruntPlan_ENV_LAYER/TerragruntInit
```
...
Switched to branch 'localBranch'
version '0.77.7' is not installed (set by /azp/_work/1/s/landing_zones_163ent-P3/dev/L1_blueprint_base/.terragrunt-version). Installing now as TGENV_AUTO_INSTALL==true
No versions matching '0.77.7' found in remote
/azp/_work/_tool/.tgenv/lib/tgenv-exec.sh: line 43: /azp/_work/_tool/.tgenv/versions/0.77.7/terragrunt: No such file or directory

##[error]Script failed with exit code: 127
/usr/bin/az account clear
Finishing: TerragruntInit
```
